### PR TITLE
Move capsule to development requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,7 @@
     "require": {
 		"php": "^8.0",
 		"ext-json": "*",
-        "psr/http-client": "^1.0",
-        "nimbly/capsule": "^2.0"
+        "psr/http-client": "^1.0"
 	},
 	"provide": {
 		"psr/http-client-implementation": "^1.0"
@@ -35,7 +34,8 @@
         "vimeo/psalm": "^4.0",
         "phpunit/phpunit": "^9.0",
         "php-coveralls/php-coveralls": "^2.1",
-        "symfony/var-dumper": "^4.2"
+        "symfony/var-dumper": "^4.2",
+        "nimbly/capsule": "^2.0"
 	},
 	"autoload-dev": {
         "psr-4": {


### PR DESCRIPTION
Another suggestion, move capsule to development requirements as any PSR-7 request works. I personally use the one from httpsoft.